### PR TITLE
fix(docs): optimize playground URL — use ?pro=1 param and slim hash payload

### DIFF
--- a/docs/src/components/code-demo/utils/playground.ts
+++ b/docs/src/components/code-demo/utils/playground.ts
@@ -1,26 +1,25 @@
-export const baseConfig = {
-  'App.vue': '',
-  'antdv-next.js': 'import Antd from \'antdv-next\'\nimport Pro from \'@antdv-next/pro\'\nimport { getCurrentInstance } from \'vue\'\n\nlet installed = false\nawait loadStyle()\n\nexport function setupAntdvNext() {\n  if (installed) return\n  const instance = getCurrentInstance()\n  instance.appContext.app.use(Antd)\n  instance.appContext.app.use(Pro)\n  installed = true\n}\n\nexport function loadStyle() {\n  const styles = [\'https://cdn.jsdelivr.net/npm/antdv-next@latest/dist/reset.css\', \'https://cdn.jsdelivr.net/npm/antdv-next@latest/dist/antd.css\'].map((style) => {\n    return new Promise((resolve, reject) => {\n      const link = document.createElement(\'link\')\n      link.rel = \'stylesheet\'\n      link.href = style\n      link.addEventListener(\'load\', resolve)\n      link.addEventListener(\'error\', reject)\n      document.body.append(link)\n    })\n  })\n  return Promise.allSettled(styles)\n}\n',
-  'tsconfig.json': '{\n  "compilerOptions": {\n    "target": "ESNext",\n    "jsx": "preserve",\n    "module": "ESNext",\n    "moduleResolution": "Bundler",\n    "types": ["antdv-next/global.d.ts"],\n    "allowImportingTsExtensions": true,\n    "allowJs": true,\n    "checkJs": true\n  },\n  "vueCompilerOptions": {\n    "target": 3.3\n  }\n}\n',
-  'PlaygroundMain.vue': '<script setup>\nimport { theme } from \'antdv-next\'\nimport { computed, onMounted, onUnmounted, ref } from \'vue\'\nimport { setupAntdvNext } from \'./antdv-next.js\'\nimport App from \'./App.vue\'\nsetupAntdvNext()\n\nconst { darkAlgorithm, defaultAlgorithm } = theme\nconst isDark = ref(document.documentElement.classList.contains(\'dark\'))\n\nconst themeConfig = computed(() => ({\n  algorithm: isDark.value ? darkAlgorithm : defaultAlgorithm,\n}))\n\nlet observer\nonMounted(() => {\n  observer = new MutationObserver(() => {\n    isDark.value = document.documentElement.classList.contains(\'dark\')\n  })\n  observer.observe(document.documentElement, {\n    attributes: true,\n    attributeFilter: [\'class\'],\n  })\n})\nonUnmounted(() => observer?.disconnect())\n</script>\n\n<template>\n  <a-config-provider :theme="themeConfig">\n    <App />\n  </a-config-provider>\n</template>\n',
-  // Best-effort CDN entries; pro-play.antdv-next.com owns the final module
-  // resolution (e.g. rewriting `@antdv-next/pro`'s unbundled dist imports of
-  // `antdv-next/*` subpaths onto the shared antd instance).
-  'import-map.json': '{\n  "imports": {\n    "vue": "https://cdn.jsdelivr.net/npm/@vue/runtime-dom@latest/dist/runtime-dom.esm-browser.js",\n    "@vue/shared": "https://cdn.jsdelivr.net/npm/@vue/shared@latest/dist/shared.esm-bundler.js",\n    "antdv-next": "https://cdn.jsdelivr.net/npm/antdv-next@latest/dist/antd.esm.js",\n    "antdv-next/": "https://cdn.jsdelivr.net/npm/antdv-next@latest/",\n    "@antdv-next/icons": "https://cdn.jsdelivr.net/npm/@antdv-next/icons@latest/dist/antd-icons.esm.js",\n    "@antdv-next/pro": "https://cdn.jsdelivr.net/npm/@antdv-next/pro@latest/dist/index.js",\n    "@antdv-next/pro/scrollbar": "https://cdn.jsdelivr.net/npm/@antdv-next/pro@latest/dist/scrollbar/index.js",\n    "@antdv-next/pro/": "https://cdn.jsdelivr.net/npm/@antdv-next/pro@latest/dist/"\n  },\n  "scopes": {}\n}',
-  '_o': {},
-}
-function toBase64(str: string) {
-  const bytes = new TextEncoder().encode(str)
-  let binary = ''
-  bytes.forEach(b => binary += String.fromCharCode(b))
-  return btoa(binary)
-}
+/**
+ * 为 Pro 文档站生成 Playground 链接。
+ *
+ * 协议与 antdv-next-playground 的 store.ts 对齐:
+ * - hash 负载只含 `src/App.vue` + `_o` 选项(proEnabled: true)
+ * - Playground 端根据 `?pro=1` 和 `_o.proEnabled` 自动注册 Pro 组件 & import map
+ * - 编码使用 `utoa`(encodeURIComponent + btoa),与 Playground 反序列化一致
+ */
 
+function utoa(data: string): string {
+  return btoa(unescape(encodeURIComponent(data)))
+}
 export function loadPlaygroundUrl(code: string) {
-  const baseUrl = 'https://pro-play.antdv-next.com/#'
+  const baseUrl = 'https://play.antdv-next.com/'
+
   const defaultCode = '<script setup lang="ts">\nimport { version as antdvVersion } from \'antdv-next\'\nimport { ref, version as vueVersion } from \'vue\'\n\nconst rows = Array.from({ length: 20 }, (_, i) => `Row ${i + 1}`)\n</script>\n\n<template>\n  <a-scrollbar style="height: 220px; border: 1px solid var(--ant-color-border); border-radius: 8px;">\n    <div style="padding: 12px;">\n      <p v-for="row in rows" :key="row">{{ row }}</p>\n    </div>\n  </a-scrollbar>\n\n  <p>Antdv Next {{ antdvVersion }} + Vue {{ vueVersion }}</p>\n</template>\n'
-  baseConfig['App.vue'] = code || defaultCode
-  // 转换成base64字符串
-  const base64Code = toBase64(JSON.stringify(baseConfig))
-  return baseUrl + base64Code
+
+  const state: Record<string, any> = {
+    'src/App.vue': code || defaultCode,
+    _o: { proEnabled: true },
+  }
+
+  const hash = utoa(JSON.stringify(state))
+  return `${baseUrl}?pro=1#${hash}`
 }

--- a/docs/src/layouts/base/header.vue
+++ b/docs/src/layouts/base/header.vue
@@ -50,7 +50,7 @@ const handleSiderChange: MenuEmits['click'] = (info) => {
 const handleHeaderChange: MenuEmits['click'] = (info) => {
   const key = info.key
   if (key === '/playground') {
-    window.open('https://pro-play.antdv-next.com', '_blank')
+    window.open('https://play.antdv-next.com/?pro=1', '_blank')
     return
   }
   if (key === '/sponsor') {
@@ -138,7 +138,7 @@ function changeDirection(value: 1 | 2) {
 
 function getHeaderMenuUrl(key: string) {
   if (key === '/playground')
-    return 'https://pro-play.antdv-next.com'
+    return 'https://play.antdv-next.com/?pro=1'
   if (key === '/sponsor')
     return sponsorUrl
   return key


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ⚡️ Performance optimization
- [x] 🛠 Refactoring

### 🔗 Related Issues

> 优化 Pro 文档站"在 Playground 中打开"链接的生成方式，与 antdv-next-playground 的序列化协议对齐。

### 💡 Background and Solution

> **问题：** 当前从 Pro 文档站点击"在 Playground 中打开"时，生成的 URL hash 中内联了 5 个硬编码文件（`antdv-next.js`、`PlaygroundMain.vue`、`import-map.json`、`tsconfig.json`、`App.vue`），导致 URL 非常长（~3KB base64）。同时 `import-map.json` 中所有依赖版本锁死 `@latest`，无法跟随用户在 Playground 中切换的版本。也没有告诉 Playground 需要启用 Pro 组件。
>
> **方案：** 参考 `antdv-next-playground` 的 `store.ts` 序列化协议进行优化：
>
> 1. **精简 hash 负载** — 只序列化 `src/App.vue` + `_o: { proEnabled: true }`，其余文件由 Playground 端根据 feature flags 自动生成
> 2. **添加 `?pro=1` 查询参数** — 让 Playground 自动启用 Pro 组件注册和 import map（对接 Playground 端已有的 `paramFlag('pro', false)` 逻辑）
> 3. **统一编码方式** — 使用与 Playground 一致的 `utoa`（`encodeURIComponent` + `btoa`），解决 Unicode 兼容性问题
> 4. **更新 header 导航链接** — Playground 菜单项也带 `?pro=1`
>
> | 项目 | 优化前 | 优化后 |
> |------|--------|--------|
> | Hash 负载大小 | ~3KB（5个文件） | ~200B-1KB（仅 App.vue + `_o`） |
> | Pro 组件支持 | ❌ 硬编码 import map | ✅ `?pro=1` + `_o.proEnabled` |
> | 编码方式 | `TextEncoder` + `btoa` | `utoa`（与 Playground 一致） |

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimized "Open in Playground" URL generation: slimmed hash payload from ~3KB to <1KB, added `?pro=1` query param for automatic Pro component activation, aligned encoding with Playground protocol. |
| 🇨🇳 Chinese | 优化"在 Playground 中打开"链接生成：hash 负载从 ~3KB 精简至 <1KB，添加 `?pro=1` 参数自动启用 Pro 组件，编码方式与 Playground 对齐。 |

### ✅ Component Contribution Checklist

- [x] I have considered backward compatibility for existing APIs and interactions.
- [x] I have run the relevant lint, typecheck, and test commands.