### PR TITLE
chore(docs): upgrade @antdv-next/docs-plugins to 0.0.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ catalogs:
       version: 3.3.6
   docs:
     '@antdv-next/docs-plugins':
-      specifier: ^0.0.2
-      version: 0.0.2
+      specifier: ^0.0.4
+      version: 0.0.4
     '@antdv-next/unocss':
       specifier: ^1.1.1
       version: 1.1.1
@@ -331,7 +331,7 @@ importers:
         version: 1.0.6(vue@3.5.39(typescript@5.9.3))
       '@antdv-next/docs-plugins':
         specifier: catalog:docs
-        version: 0.0.2(@types/markdown-it@14.1.2)(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
+        version: 0.0.4(@types/markdown-it@14.1.2)(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
       '@antdv-next/happy-work-theme':
         specifier: catalog:prod
         version: 1.0.0(antdv-next@1.3.7(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
@@ -588,8 +588,8 @@ packages:
     peerDependencies:
       vue: '>=3.2.0'
 
-  '@antdv-next/docs-plugins@0.0.2':
-    resolution: {integrity: sha512-pxlWccwfkYdGSsqNz1VC/qtjTHhzslUNvXUOFY+O7EbYQdxIPqlUDldP1rcWnhRBNCQ0nghtwmdxZCOO523pyg==}
+  '@antdv-next/docs-plugins@0.0.4':
+    resolution: {integrity: sha512-jYzrXd1aSmUaYMdJ5lmmbReYSfhLFzFCmLcNaDUkZon/X0hP+gRQASip0Gnj27j8N6nkPxiP/fNcQb32YaDDSA==}
 
   '@antdv-next/happy-work-theme@1.0.0':
     resolution: {integrity: sha512-INjE69eKPWfmwi0SySkRA7hzp0JgmkID5pqTL8FIU9O2k1ynJAYj7BS+4fFE9rRQdFN2g7dyQsUQXfIuZZc6eg==}
@@ -5869,7 +5869,7 @@ snapshots:
       stylis: 4.4.0
       vue: 3.5.39(typescript@5.9.3)
 
-  '@antdv-next/docs-plugins@0.0.2(@types/markdown-it@14.1.2)(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)':
+  '@antdv-next/docs-plugins@0.0.4(@types/markdown-it@14.1.2)(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.7)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       '@mdit-vue/plugin-frontmatter': 3.0.2
       '@mdit-vue/plugin-headers': 3.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,7 +49,7 @@ catalogs:
     vitest: ^4.1.9
     vue-tsc: ^3.3.5
   docs:
-    '@antdv-next/docs-plugins': ^0.0.2
+    '@antdv-next/docs-plugins': ^0.0.4
     '@antdv-next/unocss': ^1.1.1
     '@codesandbox/sandpack-themes': ^2.0.21
     '@mdit-vue/plugin-frontmatter': 3.0.2


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] ❓ 其他（请说明）：升级 docs 依赖 @antdv-next/docs-plugins 0.0.2 → 0.0.4

### 🔗 相关 Issue

None

### 💡 背景与方案

将 pnpm catalog 中的 `@antdv-next/docs-plugins` 从 `^0.0.2` 升级到 `^0.0.4`，同步更新 lockfile。无 API/UI/交互变化。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | No changelog required |
| 🇨🇳 中文 | 无需更新日志 |

### ✅ 组件贡献检查清单

- [x] 我已运行相关的 lint、类型检查和测试命令。（`pnpm build:site` 通过）
