### PR TITLE
feat(Scrollbar): add explicit scroll fade API

### DIFF
--- a/docs/src/components/code-demo/index.vue
+++ b/docs/src/components/code-demo/index.vue
@@ -310,7 +310,6 @@ const sandpackOptions = computed(() => ({
   autorun: false,
   activeFile: sandpackActiveFile.value,
 }))
-const active = computed(() => route.hash === `#${id.value}`)
 function handleScroll(e: Event) {
   e.preventDefault()
   e.stopPropagation()
@@ -359,9 +358,6 @@ const { copied, copy } = useClipboard({
 
 const cls = computed(() => {
   const cls: string[] = []
-  if (active.value) {
-    cls.push('border-primary')
-  }
   if (simplify) {
     cls.push('ant-doc-demo-box-simplify')
   }

--- a/docs/src/pages/components/scrollbar/demo/fade.vue
+++ b/docs/src/pages/components/scrollbar/demo/fade.vue
@@ -13,9 +13,7 @@ const verticalRows = Array.from({ length: 14 }, (_, index) => `Row ${index + 1}`
 <template>
   <div style="display: flex; flex-direction: column; gap: 24px;">
     <section>
-      <h3 style="margin: 0 0 12px; font-size: 16px;">
-        Vertical
-      </h3>
+      <h3 style="margin: 0 0 12px; font-size: 16px;" v-text="'Vertical'" />
       <a-scrollbar scroll-fade="vertical" :scroll-fade-size="72" style="height: 180px; border: 1px solid var(--ant-color-border); border-radius: 12px;">
         <div style="display: flex; flex-direction: column; gap: 16px; padding: 16px;">
           <p v-for="row in verticalRows" :key="row" style="margin: 0;">

--- a/docs/src/pages/components/scrollbar/demo/fade.vue
+++ b/docs/src/pages/components/scrollbar/demo/fade.vue
@@ -1,0 +1,28 @@
+<docs lang="zh-CN">
+滚动时在内容边缘增加渐隐提示，适合密度较高的面板或侧栏。
+</docs>
+
+<docs lang="en-US">
+Add edge fade hints while scrolling. Useful for dense panels and navigation areas.
+</docs>
+
+<script setup lang="ts">
+const verticalRows = Array.from({ length: 14 }, (_, index) => `Row ${index + 1}`)
+</script>
+
+<template>
+  <div style="display: flex; flex-direction: column; gap: 24px;">
+    <section>
+      <h3 style="margin: 0 0 12px; font-size: 16px;">
+        Vertical
+      </h3>
+      <a-scrollbar scroll-fade="vertical" :scroll-fade-size="72" style="height: 180px; border: 1px solid var(--ant-color-border); border-radius: 12px;">
+        <div style="display: flex; flex-direction: column; gap: 16px; padding: 16px;">
+          <p v-for="row in verticalRows" :key="row" style="margin: 0;">
+            {{ row }}
+          </p>
+        </div>
+      </a-scrollbar>
+    </section>
+  </div>
+</template>

--- a/docs/src/pages/components/scrollbar/index.en-US.md
+++ b/docs/src/pages/components/scrollbar/index.en-US.md
@@ -22,6 +22,7 @@ group:
   <demo src="./demo/basic.vue">Basic</demo>
   <demo src="./demo/visibility.vue">Visibility modes</demo>
   <demo src="./demo/motion.vue">Visibility motion</demo>
+  <demo src="./demo/fade.vue">Vertical fade</demo>
   <demo src="./demo/sider.vue">Navigation sider</demo>
   <demo src="./demo/controller.vue">Events and scroll control</demo>
   <demo src="./demo/semantic.vue">Semantic styling</demo>
@@ -40,6 +41,8 @@ group:
 | visibilityY | Visibility strategy for vertical scrollbar | `'auto' \| 'always' \| 'hidden'` | - | - | ✓ |
 | hideDelay | Delay in milliseconds before auto-mode overlays hide after the pointer leaves the content area | `number` | `1200` | - | ✓ |
 | motion | Track visibility motion. `fade` fades in and out; `slide` slides in from the right and out to the right. | `'fade' \| 'slide'` | `'fade'` | - | ✓ |
+| scrollFade | Edge fade direction for the scroll content. Omit it to disable the effect. | `'vertical' \| 'horizontal' \| 'both'` | - | - | ✓ |
+| scrollFadeSize | Edge fade length in pixels. | `number` | `40` | - | ✓ |
 | classes | Customize class for each semantic structure inside the component. Supports object or function. | `ScrollbarClassNamesType` | - | - | ✓ |
 | styles | Customize inline style for each semantic structure inside the component. Supports object or function. | `ScrollbarStylesType` | - | - | ✓ |
 

--- a/docs/src/pages/components/scrollbar/index.zh-CN.md
+++ b/docs/src/pages/components/scrollbar/index.zh-CN.md
@@ -23,6 +23,7 @@ group:
   <demo src="./demo/basic.vue">基础用法</demo>
   <demo src="./demo/visibility.vue">显隐模式</demo>
   <demo src="./demo/motion.vue">显隐动画</demo>
+  <demo src="./demo/fade.vue">垂直渐隐</demo>
   <demo src="./demo/sider.vue">导航侧栏</demo>
   <demo src="./demo/controller.vue">事件与滚动控制</demo>
   <demo src="./demo/semantic.vue">语义化样式</demo>
@@ -41,6 +42,8 @@ group:
 | visibilityY | 纵向滚动条显隐策略 | `'auto' \| 'always' \| 'hidden'` | - | - | ✓ |
 | hideDelay | `auto` 模式下移出内容区域后自动隐藏滚动条的延时，单位为毫秒 | `number` | `1200` | - | ✓ |
 | motion | 滚动条轨道显隐动画，`fade` 为淡入淡出，`slide` 为从右侧滑入、向右侧滑出 | `'fade' \| 'slide'` | `'fade'` | - | ✓ |
+| scrollFade | 内容边缘渐隐方向，不传则关闭 | `'vertical' \| 'horizontal' \| 'both'` | - | - | ✓ |
+| scrollFadeSize | 内容边缘渐隐长度，单位像素 | `number` | `40` | - | ✓ |
 | classes | 用于自定义组件内部各语义化结构的 class，支持对象或函数 | `ScrollbarClassNamesType` | - | - | ✓ |
 | styles | 用于自定义组件内部各语义化结构的行内 style，支持对象或函数 | `ScrollbarStylesType` | - | - | ✓ |
 

--- a/packages/pro/src/config-provider/define.ts
+++ b/packages/pro/src/config-provider/define.ts
@@ -4,6 +4,7 @@ import type { ProLocale } from '../locale/types'
 
 export type ScrollbarVisibility = 'auto' | 'always' | 'hidden'
 export type ScrollbarMotion = 'fade' | 'slide'
+export type ScrollbarFade = 'vertical' | 'horizontal' | 'both'
 
 export interface ScrollbarConfig {
   visibility?: ScrollbarVisibility
@@ -11,6 +12,8 @@ export interface ScrollbarConfig {
   visibilityY?: ScrollbarVisibility
   hideDelay?: number
   motion?: ScrollbarMotion
+  scrollFade?: ScrollbarFade
+  scrollFadeSize?: number
   class?: string
   style?: CSSProperties
   classes?: Record<string, string>

--- a/packages/pro/src/config-provider/index.tsx
+++ b/packages/pro/src/config-provider/index.tsx
@@ -41,6 +41,7 @@ export type {
   ProConfigProviderProps,
   ProConfigProviderSlots,
   ScrollbarConfig,
+  ScrollbarFade,
   ScrollbarMotion,
   ScrollbarVisibility,
 } from './define'

--- a/packages/pro/src/index.ts
+++ b/packages/pro/src/index.ts
@@ -13,6 +13,7 @@ export { default as ProConfigProvider } from './config-provider'
 export type {
   ProConfigProviderProps,
   ScrollbarConfig,
+  ScrollbarFade,
   ScrollbarMotion,
   ScrollbarVisibility,
 } from './config-provider'

--- a/packages/pro/src/scrollbar/index.tsx
+++ b/packages/pro/src/scrollbar/index.tsx
@@ -1,6 +1,6 @@
 import type { App, CSSProperties, ShallowRef, SlotsType } from 'vue'
 import type { SemanticClassNamesType, SemanticStylesType } from '../_util/semantic'
-import type { ScrollbarConfig, ScrollbarMotion, ScrollbarVisibility } from '../config-provider'
+import type { ScrollbarConfig, ScrollbarFade, ScrollbarMotion, ScrollbarVisibility } from '../config-provider'
 import { clsx } from '@v-c/util'
 import { getTransitionProps } from '@v-c/util/dist/utils/transition'
 import { useBaseConfig } from 'antdv-next/config-provider/context'
@@ -49,6 +49,8 @@ export interface ScrollbarProps {
   visibilityY?: ScrollbarVisibility
   hideDelay?: number
   motion?: ScrollbarMotion
+  scrollFade?: ScrollbarFade
+  scrollFadeSize?: number
   classes?: ScrollbarClassNamesType
   styles?: ScrollbarStylesType
 }
@@ -73,12 +75,64 @@ export interface ScrollbarRef {
 const DEFAULT_VISIBILITY: ScrollbarVisibility = 'auto'
 const DEFAULT_HIDE_DELAY = 1200
 const DEFAULT_MOTION: ScrollbarMotion = 'fade'
+const DEFAULT_SCROLL_FADE_SIZE = 40
 
 function omitClassAndStyle(attrs: Record<string, any>) {
   const nextAttrs = { ...attrs }
   delete nextAttrs.class
   delete nextAttrs.style
   return nextAttrs
+}
+
+function resolveScrollFadeClassName(prefixCls: string, scrollFade: ScrollbarFade | undefined) {
+  if (!scrollFade) {
+    return undefined
+  }
+
+  return `${prefixCls}-container-fade-${scrollFade}`
+}
+
+function resolveScrollFadeStyle(
+  scrollFade: ScrollbarFade | undefined,
+  scrollFadeSize: number,
+  metrics: {
+    clientWidth: number
+    clientHeight: number
+    scrollWidth: number
+    scrollHeight: number
+    scrollLeft: number
+    scrollTop: number
+  },
+) {
+  if (!scrollFade) {
+    return undefined
+  }
+
+  const size = Math.max(scrollFadeSize, 0)
+
+  const style: CSSProperties = {
+    '--scrollbar-fade-size': `${size}px`,
+  }
+
+  if (scrollFade === 'vertical' || scrollFade === 'both') {
+    const maxScrollY = Math.max(metrics.scrollHeight - metrics.clientHeight, 0)
+
+    Object.assign(style, {
+      '--scrollbar-fade-overflow-top': `${Math.max(metrics.scrollTop, 0)}px`,
+      '--scrollbar-fade-overflow-bottom': `${Math.max(maxScrollY - metrics.scrollTop, 0)}px`,
+    })
+  }
+
+  if (scrollFade === 'horizontal' || scrollFade === 'both') {
+    const maxScrollX = Math.max(metrics.scrollWidth - metrics.clientWidth, 0)
+
+    Object.assign(style, {
+      '--scrollbar-fade-overflow-left': `${Math.max(metrics.scrollLeft, 0)}px`,
+      '--scrollbar-fade-overflow-right': `${Math.max(maxScrollX - metrics.scrollLeft, 0)}px`,
+    })
+  }
+
+  return style
 }
 
 const Scrollbar = defineComponent<
@@ -115,6 +169,14 @@ const Scrollbar = defineComponent<
       return props.motion ?? proConfig.value.motion ?? DEFAULT_MOTION
     })
 
+    const mergedScrollFade = computed<ScrollbarFade | undefined>(() => {
+      return props.scrollFade ?? proConfig.value.scrollFade
+    })
+
+    const mergedScrollFadeSize = computed(() => {
+      return props.scrollFadeSize ?? proConfig.value.scrollFadeSize ?? DEFAULT_SCROLL_FADE_SIZE
+    })
+
     const mergedConfig = computed<ScrollbarConfig>(() => {
       return {
         ...proConfig.value,
@@ -123,6 +185,8 @@ const Scrollbar = defineComponent<
         visibilityY: mergedVisibilityY.value,
         hideDelay: mergedHideDelay.value,
         motion: mergedMotion.value,
+        scrollFade: mergedScrollFade.value,
+        scrollFadeSize: mergedScrollFadeSize.value,
       }
     })
 
@@ -141,6 +205,8 @@ const Scrollbar = defineComponent<
           visibilityY: mergedVisibilityY.value,
           hideDelay: mergedHideDelay.value,
           motion: mergedMotion.value,
+          scrollFade: mergedScrollFade.value,
+          scrollFadeSize: mergedScrollFadeSize.value,
         },
       })),
     )
@@ -182,6 +248,12 @@ const Scrollbar = defineComponent<
       computed(() => mergedConfig.value.visibilityX),
       computed(() => mergedConfig.value.visibilityY),
     )
+    const scrollFadeClassName = computed(() => {
+      return resolveScrollFadeClassName(prefixCls.value, mergedScrollFade.value)
+    })
+    const scrollFadeStyle = computed(() => {
+      return resolveScrollFadeStyle(mergedScrollFade.value, mergedScrollFadeSize.value, scrollbarState.metrics.value)
+    })
     const scrollbarDrag = useScrollbarDrag(
       containerRef,
       scrollbarState.metrics,
@@ -411,8 +483,8 @@ const Scrollbar = defineComponent<
       >
         <div
           ref={containerRef}
-          class={clsx(`${prefixCls.value}-container`, mergedClassNames.value.container)}
-          style={mergedStyles.value.container}
+          class={clsx(`${prefixCls.value}-container`, scrollFadeClassName.value, mergedClassNames.value.container)}
+          style={[mergedStyles.value.container, scrollFadeStyle.value]}
           onScroll={handleScroll}
         >
           <div

--- a/packages/pro/src/scrollbar/style/index.ts
+++ b/packages/pro/src/scrollbar/style/index.ts
@@ -15,6 +15,13 @@ interface ScrollbarToken extends FullToken<'Scrollbar'> {
   inset: number
 }
 
+const fadeMaskCommon: CSSObject = {
+  maskRepeat: 'no-repeat',
+  WebkitMaskRepeat: 'no-repeat',
+  maskSize: '100% 100%',
+  WebkitMaskSize: '100% 100%',
+}
+
 const genScrollbarStyle: GenerateStyle<ScrollbarToken, CSSObject> = (token) => {
   const { componentCls, trackBg, thumbBg, thumbHoverBg, thumbActiveBg, size, radius, inset } = token
   const trackMotionCls = `${componentCls}-track-motion`
@@ -49,6 +56,48 @@ const genScrollbarStyle: GenerateStyle<ScrollbarToken, CSSObject> = (token) => {
         minWidth: '100%',
         minHeight: '100%',
         width: 'fit-content',
+      },
+
+      [`&-container-fade-vertical`]: {
+        ...fadeMaskCommon,
+        '--scrollbar-fade-overflow-top': 'inherit',
+        '--scrollbar-fade-overflow-bottom': 'inherit',
+        '--scrollbar-fade-top': 'min(var(--scrollbar-fade-size), var(--scrollbar-fade-overflow-top, 0px))',
+        '--scrollbar-fade-bottom': 'min(var(--scrollbar-fade-size), var(--scrollbar-fade-overflow-bottom, 0px))',
+        maskImage: 'linear-gradient(to bottom, transparent 0, #000 var(--scrollbar-fade-top), #000 calc(100% - var(--scrollbar-fade-bottom)), transparent 100%)',
+        WebkitMaskImage: 'linear-gradient(to bottom, transparent 0, #000 var(--scrollbar-fade-top), #000 calc(100% - var(--scrollbar-fade-bottom)), transparent 100%)',
+      },
+
+      [`&-container-fade-horizontal`]: {
+        ...fadeMaskCommon,
+        '--scrollbar-fade-overflow-left': 'inherit',
+        '--scrollbar-fade-overflow-right': 'inherit',
+        '--scrollbar-fade-left': 'min(var(--scrollbar-fade-size), var(--scrollbar-fade-overflow-left, 0px))',
+        '--scrollbar-fade-right': 'min(var(--scrollbar-fade-size), var(--scrollbar-fade-overflow-right, 0px))',
+        maskImage: 'linear-gradient(to right, transparent 0, #000 var(--scrollbar-fade-left), #000 calc(100% - var(--scrollbar-fade-right)), transparent 100%)',
+        WebkitMaskImage: 'linear-gradient(to right, transparent 0, #000 var(--scrollbar-fade-left), #000 calc(100% - var(--scrollbar-fade-right)), transparent 100%)',
+      },
+
+      [`&-container-fade-both`]: {
+        ...fadeMaskCommon,
+        '--scrollbar-fade-overflow-top': 'inherit',
+        '--scrollbar-fade-overflow-bottom': 'inherit',
+        '--scrollbar-fade-overflow-left': 'inherit',
+        '--scrollbar-fade-overflow-right': 'inherit',
+        '--scrollbar-fade-top': 'min(var(--scrollbar-fade-size), var(--scrollbar-fade-overflow-top, 0px))',
+        '--scrollbar-fade-bottom': 'min(var(--scrollbar-fade-size), var(--scrollbar-fade-overflow-bottom, 0px))',
+        '--scrollbar-fade-left': 'min(var(--scrollbar-fade-size), var(--scrollbar-fade-overflow-left, 0px))',
+        '--scrollbar-fade-right': 'min(var(--scrollbar-fade-size), var(--scrollbar-fade-overflow-right, 0px))',
+        maskComposite: 'intersect',
+        WebkitMaskComposite: 'source-in',
+        maskImage: [
+          'linear-gradient(to bottom, transparent 0, #000 var(--scrollbar-fade-top), #000 calc(100% - var(--scrollbar-fade-bottom)), transparent 100%)',
+          'linear-gradient(to right, transparent 0, #000 var(--scrollbar-fade-left), #000 calc(100% - var(--scrollbar-fade-right)), transparent 100%)',
+        ].join(', '),
+        WebkitMaskImage: [
+          'linear-gradient(to bottom, transparent 0, #000 var(--scrollbar-fade-top), #000 calc(100% - var(--scrollbar-fade-bottom)), transparent 100%)',
+          'linear-gradient(to right, transparent 0, #000 var(--scrollbar-fade-left), #000 calc(100% - var(--scrollbar-fade-right)), transparent 100%)',
+        ].join(', '),
       },
 
       [`&-track`]: {

--- a/packages/pro/src/scrollbar/tests/__snapshots__/demo.test.ts.snap
+++ b/packages/pro/src/scrollbar/tests/__snapshots__/demo.test.ts.snap
@@ -713,6 +713,140 @@ exports[`scrollbar demo > renders controller correctly 1`] = `
 </div>
 `;
 
+exports[`scrollbar demo > renders fade correctly 1`] = `
+<div
+  style="display: flex; flex-direction: column; gap: 24px;"
+>
+  <section>
+    <h3
+      style="margin: 0px 0px 12px; font-size: 16px;"
+    >
+      Vertical
+    </h3>
+    <div
+      class="ant-scrollbar css-var-root ant-scrollbar-css-var"
+      data-active=""
+      data-visibility="auto"
+      data-visibility-x="auto"
+      data-visibility-y="auto"
+      style="height: 180px; border: 1px solid var(--ant-color-border); border-radius: 12px;"
+    >
+      <div
+        class="ant-scrollbar-container ant-scrollbar-container-fade-vertical"
+        style="--scrollbar-fade-size: 72px; --scrollbar-fade-overflow-top: 0px; --scrollbar-fade-overflow-bottom: 0px;"
+      >
+        <div
+          class="ant-scrollbar-content"
+        >
+          <div
+            style="display: flex; flex-direction: column; gap: 16px; padding: 16px;"
+          >
+            <p
+              style="margin: 0px;"
+            >
+              Row 1
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 2
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 3
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 4
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 5
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 6
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 7
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 8
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 9
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 10
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 11
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 12
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 13
+            </p>
+            <p
+              style="margin: 0px;"
+            >
+              Row 14
+            </p>
+          </div>
+        </div>
+      </div>
+      <transition-stub
+        appear="false"
+        css="true"
+        enteractiveclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-enter ant-scrollbar-track-fade-motion-appear ant-scrollbar-track-fade-motion-appear-prepare ant-scrollbar-track-fade-motion-enter-prepare "
+        enterfromclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-enter ant-scrollbar-track-fade-motion-appear ant-scrollbar-track-fade-motion-appear-prepare ant-scrollbar-track-fade-motion-enter-prepare ant-scrollbar-track-fade-motion-enter-start"
+        entertoclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-enter ant-scrollbar-track-fade-motion-appear ant-scrollbar-track-fade-motion-appear-active ant-scrollbar-track-fade-motion-enter-active"
+        leaveactiveclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-leave ant-scrollbar-track-fade-motion-leave-active"
+        leavefromclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-leave"
+        leavetoclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-leave ant-scrollbar-track-fade-motion-leave-active"
+        name="ant-scrollbar-track-fade-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+      <transition-stub
+        appear="false"
+        css="true"
+        enteractiveclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-enter ant-scrollbar-track-fade-motion-appear ant-scrollbar-track-fade-motion-appear-prepare ant-scrollbar-track-fade-motion-enter-prepare "
+        enterfromclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-enter ant-scrollbar-track-fade-motion-appear ant-scrollbar-track-fade-motion-appear-prepare ant-scrollbar-track-fade-motion-enter-prepare ant-scrollbar-track-fade-motion-enter-start"
+        entertoclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-enter ant-scrollbar-track-fade-motion-appear ant-scrollbar-track-fade-motion-appear-active ant-scrollbar-track-fade-motion-enter-active"
+        leaveactiveclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-leave ant-scrollbar-track-fade-motion-leave-active"
+        leavefromclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-leave"
+        leavetoclass="ant-scrollbar-track-fade-motion ant-scrollbar-track-fade-motion-leave ant-scrollbar-track-fade-motion-leave-active"
+        name="ant-scrollbar-track-fade-motion"
+        persisted="false"
+      >
+        <!---->
+      </transition-stub>
+    </div>
+  </section>
+</div>
+`;
+
 exports[`scrollbar demo > renders motion correctly 1`] = `
 <div
   class="ant-row css-var-root"

--- a/packages/pro/src/scrollbar/tests/scrollbar.test.ts
+++ b/packages/pro/src/scrollbar/tests/scrollbar.test.ts
@@ -187,6 +187,95 @@ describe('Scrollbar', () => {
     expect(wrapper.find('.ant-scrollbar-thumb-x').classes()).toContain('scrollbar-thumb-x')
   })
 
+  it.each([
+    [
+      'vertical',
+      'ant-scrollbar-container-fade-vertical',
+      [
+        '--scrollbar-fade-size: 32px',
+        '--scrollbar-fade-overflow-top: 10px',
+        '--scrollbar-fade-overflow-bottom: 130px',
+      ],
+    ],
+    [
+      'horizontal',
+      'ant-scrollbar-container-fade-horizontal',
+      [
+        '--scrollbar-fade-size: 32px',
+        '--scrollbar-fade-overflow-left: 12px',
+        '--scrollbar-fade-overflow-right: 128px',
+      ],
+    ],
+    [
+      'both',
+      'ant-scrollbar-container-fade-both',
+      [
+        '--scrollbar-fade-size: 32px',
+        '--scrollbar-fade-overflow-top: 10px',
+        '--scrollbar-fade-overflow-bottom: 130px',
+        '--scrollbar-fade-overflow-left: 12px',
+        '--scrollbar-fade-overflow-right: 128px',
+      ],
+    ],
+  ])('applies scroll fade class for %s', async (scrollFade, expectedClass, styleAssertions) => {
+    const wrapper = mount(Scrollbar, {
+      props: {
+        scrollFade: scrollFade as 'vertical' | 'horizontal' | 'both',
+        scrollFadeSize: 32,
+      },
+    })
+
+    const container = wrapper.find('.ant-scrollbar-container')
+    mockScrollMetrics(container.element, {
+      clientHeight: 100,
+      scrollHeight: 240,
+      scrollTop: 10,
+      clientWidth: 100,
+      scrollWidth: 240,
+      scrollLeft: 12,
+    })
+
+    await container.trigger('scroll')
+    await nextTick()
+
+    const content = wrapper.find('.ant-scrollbar-container')
+    expect(content.classes()).toContain(expectedClass)
+    styleAssertions.forEach((styleAssertion) => {
+      expect(content.attributes('style')).toContain(styleAssertion)
+    })
+  })
+
+  it('uses scroll fade from ProConfigProvider', async () => {
+    const wrapper = mount(ProConfigProvider, {
+      props: {
+        scrollbar: {
+          scrollFade: 'both',
+          scrollFadeSize: 24,
+        },
+      },
+      slots: {
+        default: () => h(Scrollbar),
+      },
+    })
+
+    const container = wrapper.find('.ant-scrollbar-container')
+    mockScrollMetrics(container.element, {
+      clientHeight: 100,
+      scrollHeight: 240,
+      scrollTop: 10,
+      clientWidth: 100,
+      scrollWidth: 240,
+      scrollLeft: 12,
+    })
+
+    await container.trigger('scroll')
+    await nextTick()
+
+    const content = wrapper.find('.ant-scrollbar-container')
+    expect(content.classes()).toContain('ant-scrollbar-container-fade-both')
+    expect(content.attributes('style')).toContain('--scrollbar-fade-size: 24px')
+  })
+
   it('supports semantic classes and styles as functions', async () => {
     const classes = vi.fn((info: { props: any }) => ({
       root: 'custom-root',


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🧩 新增组件
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [x] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [x] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [x] ⭐️ 功能增强
- [x] ⭐️ 现有组件功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

None

### 💡 背景与方案

`a-scrollbar` 原先的渐隐能力在 API 语义上容易混淆，也难以单独控制渐隐长度。
这次将能力拆成两个显式字段：

- `scrollFade`: 只表示方向，支持 `'vertical' | 'horizontal' | 'both'`
- `scrollFadeSize`: 只表示渐隐长度，单位像素，默认 `40`

渐隐效果继续通过 `mask-image` / `-webkit-mask-image` 实现，并挂在滚动容器层，不影响轨道、滑块、拖拽和 motion 行为。
同时补齐了全局配置类型，并将 docs demo 收敛为单个垂直示例，移除背景和多余装饰以突出效果。

### 📝 变更日志

| 语言 | 变更日志 |
| ---- | -------- |
| 🇺🇸 英文 | Added explicit direction and size props for `a-scrollbar` edge fade hints. |
| 🇨🇳 中文 | 为 `a-scrollbar` 新增显式的渐隐方向与尺寸配置。 |

### ✅ 组件贡献检查清单

- [x] 新增组件或组件功能增强已补充必要的文档和 Demo。
- [x] 组件行为变更已添加相关单元测试，Bug 修复已添加回归测试。
- [x] 我已考虑现有 API 和交互行为的向后兼容性。
- [x] 我已运行相关的 lint、类型检查和测试命令。
